### PR TITLE
Update map behavior and API key check

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This project is built with .
 - shadcn-ui
 - Tailwind CSS
 
+## Configuration
+
+The Supabase function `get-maps-key` expects a Google Maps API key stored in
+`GOOGLE_MAPS_API_KEY`. Make sure this key has both the Maps JavaScript API and
+the Geocoding API enabled in the Google Cloud Console. Without Geocoding access
+the interactive map will fail to look up addresses.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/ec1d4f1e-2506-4da5-a91b-34afa90cceb6) and click on Share -> Publish.

--- a/src/components/GoogleMap.tsx
+++ b/src/components/GoogleMap.tsx
@@ -10,6 +10,8 @@ interface GoogleMapProps {
   height?: number;
   className?: string;
   showFallback?: boolean;
+  latitude?: number;
+  longitude?: number;
 }
 
 const GoogleMap: React.FC<GoogleMapProps> = ({
@@ -18,7 +20,9 @@ const GoogleMap: React.FC<GoogleMapProps> = ({
   zoom = 15,
   height = 300,
   className = "",
-  showFallback = true
+  showFallback = true,
+  latitude,
+  longitude
 }) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
@@ -91,7 +95,10 @@ const GoogleMap: React.FC<GoogleMapProps> = ({
             if (status === 'OK' && results && results[0]) {
               createMapWithLocation(results[0].geometry.location);
             } else {
-              createMapWithLocation(new window.google.maps.LatLng(exactCoords.lat, exactCoords.lng));
+              console.warn(`Geocoding failed with status ${status} for address: ${address}`);
+              const fallbackLat = latitude ?? exactCoords.lat;
+              const fallbackLng = longitude ?? exactCoords.lng;
+              createMapWithLocation(new window.google.maps.LatLng(fallbackLat, fallbackLng));
             }
           } catch (mapError) {
             setError(`Map initialization failed: ${mapError instanceof Error ? mapError.message : 'Unknown error'}`);
@@ -158,7 +165,7 @@ const GoogleMap: React.FC<GoogleMapProps> = ({
     };
 
     loadGoogleMaps();
-  }, [apiKey, address, title, zoom]);
+  }, [apiKey, address, title, zoom, latitude, longitude]);
 
   if (error || !apiKey) {
     if (!showFallback) return null;

--- a/supabase/functions/get-maps-key/index.ts
+++ b/supabase/functions/get-maps-key/index.ts
@@ -13,9 +13,18 @@ Deno.serve(async (req) => {
 
   try {
     const googleMapsApiKey = Deno.env.get('GOOGLE_MAPS_API_KEY')
-    
+
     if (!googleMapsApiKey) {
       throw new Error('Google Maps API key not configured')
+    }
+
+    // Quick check to ensure Geocoding API access
+    const verifyUrl =
+      `https://maps.googleapis.com/maps/api/geocode/json?address=Boston&key=${googleMapsApiKey}`
+    const verifyRes = await fetch(verifyUrl)
+    const verifyJson = await verifyRes.json()
+    if (verifyJson.status === 'REQUEST_DENIED') {
+      throw new Error('Google Maps API key missing Geocoding API permission')
     }
 
     return new Response(


### PR DESCRIPTION
## Summary
- verify Geocoding API access in `get-maps-key`
- allow optional latitude/longitude props in `GoogleMap`
- log geocoding failures and use passed coordinates when available
- document Google Maps API requirements

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_687ef9bdbef8832893908dab70a174ab